### PR TITLE
Optional access token for external repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The release version to fetch from. Default `"latest"`.
 
 **Required** The name of the file in the release.
 
+### `token`
+Optional Personal Access Token to access external repository
+
 ## Example usage
 
 ```yaml
@@ -24,4 +27,5 @@ with:
   repo: "dsaltares/godot-wild-jam-18"
   version: "latest"
   file: "plague-linux.zip"
+  token: ${{ secrets.YOUR_TOKEN }}
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,10 @@ inputs:
   file:
     description: 'name of the file in the release to download'
     required: true
+  token:
+    description: 'optional Personal Access Token to access external repository'
+    required: false
+    default: ''
 
 runs:
   using: 'docker'
@@ -21,6 +25,7 @@ runs:
     - ${{ inputs.repo }}
     - ${{ inputs.version }}
     - ${{ inputs.file }}
+    - ${{ inputs.token }}
 
 branding:
   icon: 'download-cloud'

--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -20,7 +20,13 @@ if ! [[ -z ${INPUT_REPO} ]]; then
   REPO=$INPUT_REPO ;
 fi
 
-API_URL="https://$GITHUB_TOKEN:@api.github.com/repos/$REPO"
+# Optional personal access token for external repository
+TOKEN=$GITHUB_TOKEN
+if ! [[ -z ${INPUT_TOKEN} ]]; then
+  TOKEN=$INPUT_TOKEN
+fi
+
+API_URL="https://$TOKEN:@api.github.com/repos/$REPO"
 ASSET_ID=$(curl $API_URL/releases/${INPUT_VERSION} | jq -r ".assets | map(select(.name == \"${INPUT_FILE}\"))[0].id")
 
 if [[ -z "$ASSET_ID" ]]; then


### PR DESCRIPTION
In case of an external repository, the GITHUB_TOKEN cannot be used. An optional input parameter can store a personal access token.