### PR TITLE
🔖 expose version output from Github release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The release version to fetch from. Default `"latest"`.
 ### `token`
 Optional Personal Access Token to access external repository
 
+## Outputs
+
+### `version`
+
+The version number of the release tag. Can be used to deploy for example to itch.io
+
 ## Example usage
 
 ```yaml

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,10 @@ runs:
     - ${{ inputs.file }}
     - ${{ inputs.token }}
 
+outputs:
+  version:
+    description: 'The version of the release or tag'
+
 branding:
   icon: 'download-cloud'
   color: 'orange'

--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -27,7 +27,9 @@ if ! [[ -z ${INPUT_TOKEN} ]]; then
 fi
 
 API_URL="https://$TOKEN:@api.github.com/repos/$REPO"
-ASSET_ID=$(curl $API_URL/releases/${INPUT_VERSION} | jq -r ".assets | map(select(.name == \"${INPUT_FILE}\"))[0].id")
+RELEASE_DATA=$(curl $API_URL/releases/${INPUT_VERSION})
+ASSET_ID=$(echo $RELEASE_DATA | jq -r ".assets | map(select(.name == \"${INPUT_FILE}\"))[0].id")
+TAG_VERSION=$(echo $RELEASE_DATA | jq -r ".tag_name" | sed -e "s/^v//" | sed -e "s/^v.//")
 
 if [[ -z "$ASSET_ID" ]]; then
   echo "Could not find asset id"
@@ -40,3 +42,5 @@ curl \
   -H "Accept: application/octet-stream" \
   "$API_URL/releases/assets/$ASSET_ID" \
   -o ${INPUT_FILE}
+
+echo "::set-output name=version::$TAG_VERSION"


### PR DESCRIPTION
# Motivation

In a different step, I want to set the itch.io version to the one of the git tag. To integrate with this action, I need to access the git tag for that. Also, git tags may contain an invalid version number (e.g. v1.0) which needs to be converted to 1.0

## Example usage

```yml
uses: josephbmanley/butler-publish-itchio-action@master
env:
   BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
   CHANNEL: windows
   ITCH_GAME: cave
   ITCH_USER: bitbrain
   PACKAGE: cave-windows.zip
   VERSION: ${{ steps.download-windows.outputs.version }}
```

