### PR TITLE
Fix input version format typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `org/repo`. Defaults to the current repo.
 
 ### `version`
 
-The release version to fetch from. Default `"latest"`. If not `"latest"`, this has to be in the form `tags/<tag_name>` or `<release_id>`.
+The release version to fetch from. Default `"latest"`. If not `"latest"`, this has to be in the form `tag/<tag_name>` or `<release_id>`.
 
 ### `file`
 


### PR DESCRIPTION
- Release URL for anything other than 'latest' has the form:

    https://github.com/dsaltares/fetch-gh-release-asset/releases/tag/0.0.5

  with 'tag' being singular, not 'tags' plural.

See https://github.com/dsaltares/fetch-gh-release-asset/blob/aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c/fetch_github_asset.sh#L25
