### PR TITLE
Add target destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The release version to fetch from. Default `"latest"`. If not `"latest"`, this h
 
 ### `target`
 
-Optional target file path
+Optional target file path. Only supports paths to subdirectories of the Github Actions workspace directory
 
 ### `token`
 
@@ -38,5 +38,6 @@ with:
   repo: "dsaltares/godot-wild-jam-18"
   version: "latest"
   file: "plague-linux.zip"
+  target: "/tmp/plague-linux.zip"
   token: ${{ secrets.YOUR_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ The release version to fetch from. Default `"latest"`. If not `"latest"`, this h
 
 **Required** The name of the file in the release.
 
+### `target`
+
+Optional target file path
+
 ### `token`
+
 Optional Personal Access Token to access repository. You need to either specify this or use the ``secrets.GITHUB_TOKEN`` environment variable. Note that if you are working with a private repository, you cannot use the default ``secrets.GITHUB_TOKEN`` - you have to set up a [personal access token with at least the scope org:hook](https://github.com/dsaltares/fetch-gh-release-asset/issues/10#issuecomment-668665447).
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ with:
   repo: "dsaltares/godot-wild-jam-18"
   version: "latest"
   file: "plague-linux.zip"
-  target: "/tmp/plague-linux.zip"
+  target: "subdir/plague-linux.zip"
   token: ${{ secrets.YOUR_TOKEN }}
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,9 @@ inputs:
   file:
     description: 'name of the file in the release to download'
     required: true
+  target:
+    description: 'name of the target file path'
+    required: false
   token:
     description: 'optional Personal Access Token to access external repository'
     required: false
@@ -25,6 +28,7 @@ runs:
     - ${{ inputs.repo }}
     - ${{ inputs.version }}
     - ${{ inputs.file }}
+    - ${{ inputs.target }}
     - ${{ inputs.token }}
 
 outputs:

--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -12,7 +12,13 @@ fi
 
 REPO=$GITHUB_REPOSITORY
 if ! [[ -z ${INPUT_REPO} ]]; then
-  REPO=$INPUT_REPO ;
+  REPO=$INPUT_REPO
+fi
+
+# Optional target file path
+TARGET=$INPUT_FILE
+if ! [[ -z ${INPUT_TARGET} ]]; then
+  TARGET=$INPUT_TARGET
 fi
 
 # Optional personal access token for external repository
@@ -23,6 +29,19 @@ fi
 
 API_URL="https://$TOKEN:@api.github.com/repos/$REPO"
 RELEASE_DATA=$(curl $API_URL/releases/${INPUT_VERSION})
+MESSAGE=$(echo $RELEASE_DATA | jq -r ".message")
+
+if [[ "$MESSAGE" == "Not Found" ]]; then
+  echo "[!] Release asset not found"
+  echo "Release data: $RELEASE_DATA"
+  echo "-----"
+  echo "repo: $REPO"
+  echo "asset: $INPUT_FILE"
+  echo "target: $TARGET"
+  echo "version: $INPUT_VERSION"
+  exit 1
+fi
+
 ASSET_ID=$(echo $RELEASE_DATA | jq -r ".assets | map(select(.name == \"${INPUT_FILE}\"))[0].id")
 TAG_VERSION=$(echo $RELEASE_DATA | jq -r ".tag_name" | sed -e "s/^v//" | sed -e "s/^v.//")
 
@@ -36,6 +55,6 @@ curl \
   -L \
   -H "Accept: application/octet-stream" \
   "$API_URL/releases/assets/$ASSET_ID" \
-  -o ${INPUT_FILE}
+  -o ${TARGET}
 
 echo "::set-output name=version::$TAG_VERSION"


### PR DESCRIPTION
## Summary
Having a target destination for the download would be nice, as requested by https://github.com/dsaltares/fetch-gh-release-asset/issues/11. 

## Changes
- Added optional target destination input
- Added a bit of release failure code to mitigate failing silently
- Updated README