### PR TITLE
Create dirs as needed for target

### DIFF
--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -55,6 +55,7 @@ curl \
   -L \
   -H "Accept: application/octet-stream" \
   "$API_URL/releases/assets/$ASSET_ID" \
+  --create-dirs \
   -o ${TARGET}
 
 echo "::set-output name=version::$TAG_VERSION"


### PR DESCRIPTION
Add the ability to create nested dirs as needed based on `$TARGET`. Ref: https://curl.se/docs/manpage.html#--create-dirs