### PR TITLE
Update README to indicate runner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ with:
   target: "subdir/plague-linux.zip"
   token: ${{ secrets.YOUR_TOKEN }}
 ```
+
+## Support
+
+This action only supports Linux runners as this is a [docker container](https://docs.github.com/en/actions/creating-actions/about-actions#types-of-actions) action. If you encounter `Error: Container action is only supported on Linux` then you are using non-linux runner. If you need cross-platform support, you may try [pozetroninc/github-action-get-latest-release](https://github.com/pozetroninc/github-action-get-latest-release), which uses JavaScript and works cross-platform.


### PR DESCRIPTION
Add a support section to highlight that this action is a docker action and will only run on linux runners. Also point to a similar action that works cross-platform.