### PR TITLE
Don't send token header when token is not set

### DIFF
--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -11,25 +11,26 @@ if [[ -z "$GITHUB_REPOSITORY" ]]; then
 fi
 
 REPO=$GITHUB_REPOSITORY
-if ! [[ -z ${INPUT_REPO} ]]; then
+if [[ -n ${INPUT_REPO} ]]; then
   REPO=$INPUT_REPO
 fi
 
 # Optional target file path
 TARGET=$INPUT_FILE
-if ! [[ -z ${INPUT_TARGET} ]]; then
+if [[ -n ${INPUT_TARGET} ]]; then
   TARGET=$INPUT_TARGET
 fi
 
 # Optional personal access token for external repository
 TOKEN=$GITHUB_TOKEN
-if ! [[ -z ${INPUT_TOKEN} ]]; then
+if [[ -n ${INPUT_TOKEN} ]]; then
   TOKEN=$INPUT_TOKEN
 fi
 
 API_URL="https://api.github.com/repos/$REPO"
-RELEASE_DATA=$(curl -H "Authorization: token $TOKEN" $API_URL/releases/${INPUT_VERSION})
-MESSAGE=$(echo $RELEASE_DATA | jq -r ".message")
+RELEASE_DATA=$(curl ${TOKEN:+"-H"} ${TOKEN:+"Authorization: token ${TOKEN}"} \
+                    "$API_URL/releases/${INPUT_VERSION}")
+MESSAGE=$(echo "$RELEASE_DATA" | jq -r ".message")
 
 if [[ "$MESSAGE" == "Not Found" ]]; then
   echo "[!] Release asset not found"
@@ -42,10 +43,12 @@ if [[ "$MESSAGE" == "Not Found" ]]; then
   exit 1
 fi
 
-ASSET_ID=$(echo $RELEASE_DATA | jq -r ".assets | map(select(.name == \"${INPUT_FILE}\"))[0].id")
-TAG_VERSION=$(echo $RELEASE_DATA | jq -r ".tag_name" | sed -e "s/^v//" | sed -e "s/^v.//")
-RELEASE_NAME=$(echo $RELEASE_DATA | jq -r ".name")
-RELEASE_BODY=$(echo $RELEASE_DATA | jq -r ".body")
+echo "MESSAGE: '$RELEASE_DATA'"
+
+ASSET_ID=$(echo "$RELEASE_DATA" | jq -r ".assets | map(select(.name == \"${INPUT_FILE}\"))[0].id")
+TAG_VERSION=$(echo "$RELEASE_DATA" | jq -r ".tag_name" | sed -e "s/^v//" | sed -e "s/^v.//")
+RELEASE_NAME=$(echo "$RELEASE_DATA" | jq -r ".name")
+RELEASE_BODY=$(echo "$RELEASE_DATA" | jq -r ".body")
 
 if [[ -z "$ASSET_ID" ]]; then
   echo "Could not find asset id"
@@ -56,10 +59,10 @@ curl \
   -J \
   -L \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: token $TOKEN" \
+  ${TOKEN:+"-H"} ${TOKEN:+"Authorization: token ${TOKEN}"} \
   "$API_URL/releases/assets/$ASSET_ID" \
   --create-dirs \
-  -o ${TARGET}
+  -o "${TARGET}"
 
 echo "::set-output name=version::$TAG_VERSION"
 echo "::set-output name=name::$RELEASE_NAME"


### PR DESCRIPTION
Seems like github changes its policy: now, sending and empty token header results in a 403 error.
This commit fixes my CI. 