### PR TITLE
Check a hash and retry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN	apk add --no-cache \
   ca-certificates \
   curl \
   wget \
+  sha256sum \
   jq
 
 COPY fetch_github_asset.sh /fetch_github_asset.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:latest
 
-RUN	apk add --no-cache \
+RUN	apk update && apk add --no-cache \
   bash \
   ca-certificates \
   curl \
   wget \
-  sha256sum \
+  outils-sha256 \
   jq
 
 COPY fetch_github_asset.sh /fetch_github_asset.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN	apk update && apk add --no-cache \
+RUN	apk add --no-cache \
   bash \
   ca-certificates \
   curl \

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ inputs:
     required: false
   token:
     description: 'The GitHub token. Typically this will be secrets.GITHUB_TOKEN'
-    required: true
+    required: false
     default: ${{ github.token }}
   hash:
     description: 'Hash which should match the file. If present, check the hash of the file. If the hash does not match, exit with failure.'

--- a/action.yaml
+++ b/action.yaml
@@ -21,8 +21,12 @@ inputs:
     required: true
     default: ${{ github.token }}
   hash:
-    description: 'Hash which should match the file. Retries once if hash does not match.'
+    description: 'Hash which should match the file. If present, check the hash of the file. If the hash does not match, exit with failure.'
     required: false
+  retries: 
+    description: 'defaults to 0, this is the number of times to retry'
+    required: false
+    default: 0
 
 runs:
   using: 'docker'
@@ -34,6 +38,7 @@ runs:
     - ${{ inputs.target }}
     - ${{ inputs.token }}
     - ${{ inputs.hash }}
+    - ${{ inputs.retries }}
 
 outputs:
   version:

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,9 @@ inputs:
   token:
     description: 'The GitHub token. Typically this will be secrets.GITHUB_TOKEN'
     required: true
+  hash:
+    description: 'Hash which should match the file. Retries once if hash does not match.'
+    required: false
 
 runs:
   using: 'docker'
@@ -29,6 +32,7 @@ runs:
     - ${{ inputs.file }}
     - ${{ inputs.target }}
     - ${{ inputs.token }}
+    - ${{ inputs.hash }}
 
 outputs:
   version:

--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -68,7 +68,7 @@ if [[ -z $HASH ]]; then
     "$API_URL/releases/assets/$ASSET_ID" \
     --create-dirs \
     -o "${TARGET}"
-elif
+else
   n=0
   until [ "$n" -ge 2 ]
   do
@@ -84,7 +84,6 @@ elif
     n=$((n+1)) 
     sleep 15
   done
-  
 fi
 
 echo "::set-output name=version::$TAG_VERSION"

--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -80,7 +80,7 @@ else
       "$API_URL/releases/assets/$ASSET_ID" \
       --create-dirs \
       -o "${TARGET}" \
-      && echo $HASH' *'$TARGET | shasum -c && break 
+      && echo $HASH' *'$TARGET | sha256sum -c && break 
     n=$((n+1)) 
     sleep 15
   done

--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -31,6 +31,12 @@ if [[ -n ${INPUT_HASH} ]]; then
   HASH=$INPUT_HASH
 fi
 
+if [[ -n ${INPUT_RETRIES//[0-9]/} ]]; then
+  RETRIES=$INPUT_RETRIES
+else
+  RETRIES=0
+fi
+
 API_URL="https://api.github.com/repos/$REPO"
 RELEASE_DATA=$(curl ${TOKEN:+"-H"} ${TOKEN:+"Authorization: token ${TOKEN}"} \
                     "$API_URL/releases/${INPUT_VERSION}")
@@ -63,6 +69,8 @@ if [[ -z $HASH ]]; then
   curl \
     -J \
     -L \
+    --retry $RETRIES \
+    --retry-delay 5 \
     -H "Accept: application/octet-stream" \
     ${TOKEN:+"-H"} ${TOKEN:+"Authorization: token ${TOKEN}"} \
     "$API_URL/releases/assets/$ASSET_ID" \
@@ -71,7 +79,7 @@ if [[ -z $HASH ]]; then
 else
   SUCCESS=0
   n=0
-  until [ "$n" -ge 2 ]
+  until [ "$n" -gt $((RETRIES+1)) ]
   do
     curl \
       -J \


### PR DESCRIPTION
We've been running into a weird error where this action would say it had successfully downloaded the file but it hadn't.

The file it had actually downloaded was 922 bytes instead of the 32MB file it was supposed to have downloaded.

Wanted to give it the ability to retry so I added the option to pass in a hash and, if the hash doesn't match the file downloaded, try again. Even if the retry doesn't work at least it will properly error out instead of failing silently.

I also thought about going off of filesize (since that is included in the github message) but I had problems getting that working and hash seemed safer.
