### PR TITLE
feat: support unauthenticated requests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13824,9 +13824,10 @@ var baseFetchAssetFile = async (octokit, { id, outputPath, owner, repo, token })
     repo
   });
   let headers = {
-    accept,
-    authorization: `token ${token}`
+    accept
   };
+  if (token !== "")
+    headers = { ...headers, authorization: `token ${token}` };
   if (typeof userAgent !== "undefined")
     headers = { ...headers, "user-agent": userAgent };
   const response = await fetch(url, { body, headers, method });

--- a/index.ts
+++ b/index.ts
@@ -88,8 +88,10 @@ const baseFetchAssetFile = async (
   );
   let headers: HeadersInit = {
     accept,
-    authorization: `token ${token}`,
   };
+  if (token !== '')
+    headers = { ...headers, authorization: `token ${token}` };
+
   if (typeof userAgent !== 'undefined')
     headers = { ...headers, 'user-agent': userAgent };
 


### PR DESCRIPTION
GitHub API behaves differently for authenticated and unauthenticated requests.

For example IP whitelisting for organisations is influenced by the type of the request.

This will allow unauthenticated requests to GitHub API if `token: ""` is passed.