### PR TITLE
Update to node24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ inputs:
     description: 'The Github API base URL. Useful if you are using Github Enterprise.'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 
 outputs:


### PR DESCRIPTION
GitHub has announced that starting June 2, 2026, Node.js 24 will become the default, and earlier versions will be restricted to ensure security and performance standards.